### PR TITLE
Force StorageAccount Lowercase / DnsServer on NetworkInterface

### DIFF
--- a/101-simple-windows-vm/azuredeploy.json
+++ b/101-simple-windows-vm/azuredeploy.json
@@ -118,7 +118,7 @@
         },
         {
             "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('newStorageAccountName')]",
+            "name": "[toLower(parameters('newStorageAccountName'))]",
             "apiVersion": "2015-06-15",
             "location": "[variables('location')]",
             "properties": {
@@ -177,6 +177,9 @@
                 "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
             ],
             "properties": {
+                "dnsSettings": {
+                    "dnsServers": ["192.168.100.2"]
+                },
                 "ipConfigurations": [
                     {
                         "name": "ipconfig1",


### PR DESCRIPTION
StorageAccount:
Just to avoid mistakes while deploying this template. When you enter a StorageAccount-Name with an Uppercase character it fails. The "toLower" feature of ARM fixes this.
Future improvement: Do the same via variables as  the "newStorageAccountName"-parameter is still used in various other places and might have an Uppercase character. But that does not hurt for now.

DNSServers:
For the VirtualNetwork, the IP address of the DNS Server is hardcoded. However, it seems like it does not propagate through to the NetworkInterface (don't know if it should do that automatically). Anyway, the same IP is hardcoded for the NetworkInterface now.